### PR TITLE
Fix for issue with new version of Numpy

### DIFF
--- a/pyldm/fit/data.py
+++ b/pyldm/fit/data.py
@@ -53,8 +53,8 @@ class Data(object):
             print("Data set does not contain 0 time point. Setting start time to first positive time point.")
             self.izero = np.where(self.times > 0)[0][0]
 	self.wls_work = np.copy(self.wls)
-	self.data_work = np.copy(self.data_dechirped[self.izero:,:])
-	self.times_work = np.copy(self.times[self.izero:])
+	self.data_work = np.copy(self.data_dechirped[self.izero[0]:,:])
+	self.times_work = np.copy(self.times[self.izero[0]:])
 	self.U, self.S, self.Vt = np.linalg.svd(self.data_work, full_matrices=False)
 
     def truncData(self, wLSVs):


### PR DESCRIPTION
Upon trying to read in the test data the program throws the error "only integer scalar arrays can be converted to a scalar index".

"This appears to be an issue with the latest version of Numpy. A recent change made it an error to treat a single-element array as a scalar for the purposes of indexing." <--- https://stackoverflow.com/questions/42128830/typeerror-only-integer-scalar-arrays-can-be-converted-to-a-scalar-index

Fixed by indexing the desired value in the single scalar array. Thanks for the work on this!